### PR TITLE
FIX: Next button links to page 1 when no page set

### DIFF
--- a/src/js/list.js
+++ b/src/js/list.js
@@ -38,7 +38,7 @@ async function fetchPage() {
             link.appendChild(linkText);
         } else if(i > body.total_pages) { //if i > total_pages we are creating the next link
             link.setAttribute("aria-label","Previous");
-            if(urlParams.get('page') < body.total_pages) {
+            if(urlParams.get('page') && urlParams.get('page') < body.total_pages) {
                 newUrlParams.set('page', +urlParams.get('page')+1);
                 link.href = pageURL + "?" + newUrlParams.toString();
             }


### PR DESCRIPTION
There was an issue where when the page is not set on index (?page=), the next button is enabled and links to ?page=1 which displays the same data.